### PR TITLE
fix intializefill to continue instead of break cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-manager-fs-stream",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "file system store for node cache manager with binary data as files",
   "keywords": [
     "cache-manager",

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,12 +312,12 @@ export class DiskStore implements Store {
     for (const file of files) {
       if (!/\.dat$/.test(file)) {
         // only .dat files, no .bin files read
-        return;
+        continue;
       }
 
       const filename = join(this.options.path, file);
       if (!(await exists(filename))) {
-        return;
+        continue;
       }
 
       try {


### PR DESCRIPTION
You return from for cycle if file is not `.dat`, should continue the cycle