### PR TITLE
Fix cache load from files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -312,12 +312,12 @@ export class DiskStore implements Store {
     for (const file of files) {
       if (!/\.dat$/.test(file)) {
         // only .dat files, no .bin files read
-        return;
+        continue;
       }
 
       const filename = join(this.options.path, file);
       if (!(await exists(filename))) {
-        return;
+        continue;
       }
 
       try {


### PR DESCRIPTION
There is a bug in the startup cache loading from files. It broke the cycle if file doesn't has .dat extension, but should just skip this file and continue the cycle.